### PR TITLE
Screen capture service URL as a variable

### DIFF
--- a/luggage_resources.admin.inc
+++ b/luggage_resources.admin.inc
@@ -16,3 +16,9 @@ function luggage_resources_settings() {
 
   return system_settings_form($form);
 }
+
+function luggage_resources_settings_validate($form, &$form_state) {
+  if (!valid_url($form_state['values']['luggage_resources_screenshot_url'], true)) {
+    form_set_error('luggage_resources_screenshot_url', t("Please enter a valid URL."));
+  }
+}

--- a/luggage_resources.admin.inc
+++ b/luggage_resources.admin.inc
@@ -1,0 +1,18 @@
+<?php
+
+function luggage_resources_settings() {
+  // Add form to get screenshot server URL.
+  $form['resources'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Configure Luggage Resources'),
+  );
+
+  $form['resources']['luggage_resources_screenshot_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('URL of screenshot generator'),
+    '#default_value' => variable_get('luggage_resources_screenshot_url', 'http://api.ent.iastate.edu/screenshot/generate.wsgi'),
+    '#description' => t('This is the service that generates the screenshot for Luggage resources nodes.<br />Be sure to include http:// or https://.')
+  );
+
+  return system_settings_form($form);
+}

--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -302,7 +302,9 @@ function _luggage_resources_get_screenshot($url) {
 
   // Encode url and create query string.
   // Request Image from service
-  $screenshot = drupal_http_request('http://api.ent.iastate.edu/screenshot/generate.wsgi?' . drupal_http_build_query(array('uri' => urlencode($url))),$options = array('max_redirects' => 0));
+  $screenshot_url = variable_get('luggage_resources_screenshot_url', 'http://api.ent.iastate.edu/screenshot/generate.wsgi');
+  watchdog('luggage', $screenshot_url . '?' . drupal_http_build_query(array('uri' => urlencode($url))),$options = array('max_redirects' => 0));
+  //$screenshot = drupal_http_request($screenshot_url . '?' . drupal_http_build_query(array('uri' => urlencode($url))),$options = array('max_redirects' => 0));
 
   // Get contents and save into Drupal
   if (isset($screenshot->redirect_url)) {

--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -320,8 +320,7 @@ function _luggage_resources_get_screenshot($url) {
   // Encode url and create query string.
   // Request Image from service
   $screenshot_url = variable_get('luggage_resources_screenshot_url', 'http://api.ent.iastate.edu/screenshot/generate.wsgi');
-  watchdog('luggage', $screenshot_url . '?' . drupal_http_build_query(array('uri' => urlencode($url))),$options = array('max_redirects' => 0));
-  //$screenshot = drupal_http_request($screenshot_url . '?' . drupal_http_build_query(array('uri' => urlencode($url))),$options = array('max_redirects' => 0));
+  $screenshot = drupal_http_request($screenshot_url . '?' . drupal_http_build_query(array('uri' => urlencode($url))),$options = array('max_redirects' => 0));
 
   // Get contents and save into Drupal
   if (isset($screenshot->redirect_url)) {

--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -7,6 +7,23 @@
 include_once 'luggage_resources.features.inc';
 
 /**
+ * Implementation of hook_menu().
+ */
+function luggage_resources_menu() {
+  $items['admin/config/system/resources'] = array(
+    'title' => 'Luggage Resources',
+    'description' => 'Configure Luggage Resources.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('luggage_resources_settings'),
+    'access arguments' => array('configure luggage resources'),
+    'file' => 'luggage_resources.admin.inc',
+  );
+
+  return $items;
+}
+
+
+/**
  * Implements hook_update_projects_alter().
  */
 function luggage_resources_update_projects_alter(&$projects) {


### PR DESCRIPTION
The URL for the screen capture service was hard coded into the luggage_resources feature. With this pull request, I've made that URL into a variable called luggage_resources_screenshot_url.

I also made a configuration page at config/system/resources, so people can easily change this variable. Enclosed is a screenshot of that configuration page.

Brian
![screen shot 2015-08-26 at 10 52 23 am](https://cloud.githubusercontent.com/assets/8440187/9498759/20c9e210-4be1-11e5-8c64-0fff8b03f397.png)
