### PR TITLE
LUGG-654 - Add read more settings

### DIFF
--- a/luggage_resources.info
+++ b/luggage_resources.info
@@ -92,5 +92,6 @@ features[variable][] = node_options_resource
 features[variable][] = node_preview_resource
 features[variable][] = node_submitted_resource
 features[variable][] = publishcontent_resource
+features[variable][] = read_more_resource_view_modes
 features[views_view][] = my_resources
 github = https://raw.github.com/isubit/luggage_resources/master/luggage_resources.info

--- a/luggage_resources.strongarm.inc
+++ b/luggage_resources.strongarm.inc
@@ -129,5 +129,21 @@ function luggage_resources_strongarm() {
   $strongarm->value = 1;
   $export['publishcontent_resource'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'read_more_resource_view_modes';
+  $strongarm->value = array(
+    'teaser' => 'teaser',
+    'search_result' => 'search_result',
+    'full' => 0,
+    'rss' => 0,
+    'search_index' => 0,
+    'diff_standard' => 0,
+    'token' => 0,
+    'revision' => 0,
+  );
+  $export['read_more_resource_view_modes'] = $strongarm;
+
   return $export;
 }


### PR DESCRIPTION
Added strongarm settings for the read more module.

To test:
Pull down these changes on a site with an updated version of the read more module
Run "drush fra -y" on the site you're using for testing
Go to Administration > Configuration > Content Authoring > Read More link
Scroll down to the "Content Types" section of configuration
Verify that teaser and search result highlighting input boxes are both checked for resource
