### PR TITLE
LUGG-227 Wrongness on Resource Miss

### DIFF
--- a/luggage_resources.views_default.inc
+++ b/luggage_resources.views_default.inc
@@ -66,14 +66,6 @@ function luggage_resources_views_default_views() {
       'empty_column' => 0,
     ),
   );
-  /* No results behavior: Global: Text area */
-  $handler->display->display_options['empty']['area']['id'] = 'area';
-  $handler->display->display_options['empty']['area']['table'] = 'views';
-  $handler->display->display_options['empty']['area']['field'] = 'area';
-  $handler->display->display_options['empty']['area']['label'] = 'Empty view text';
-  $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'You have not yet entered any resources. Please enter a resource - <a href="/node/add/resource">Add Resource</a>';
-  $handler->display->display_options['empty']['area']['format'] = 'wysiwyg';
   /* Relationship: Content: Author */
   $handler->display->display_options['relationships']['uid']['id'] = 'uid';
   $handler->display->display_options['relationships']['uid']['table'] = 'node';


### PR DESCRIPTION
Removed text that linked to a resource creation page when there were no resources to retrieve. This link would show even when the user was anonymous and had no access to resource creation.