### PR TITLE
LUGG-769 Changed targeting for resource grid

### DIFF
--- a/css/luggage_resources.css
+++ b/css/luggage_resources.css
@@ -24,7 +24,7 @@
 
 /*-----resources grid view styling-----*/
 
-.view-display-id-resource_grid .views-row {
+.view-id-resources .views-row {
   background: rgba(255, 255, 255, 0.7);
   border: 1px solid #ddd;
   margin: 0.25em;
@@ -35,7 +35,7 @@
   overflow: hidden;
 }
 
-.view-resources.view-id-resources.view-display-id-resource_grid.resource-wrapper {
+.view-resources.view-id-resources.resource-wrapper {
   min-width: 480px
 }
 .views-field-title {


### PR DESCRIPTION
Right now, if you clone the resource view, it won't be styled correctly because of poor CSS targeting. You can see this in action on the NRSDST site, where the cloned resource views don't have the resource grid styling.
I also tested this patch with table-style resource views to double-check they weren't broken by this CSS.

To test:

*  Clone a resource view
*  Pull down changes
*  Make sure your new resource view is feature locked, then run drush fra -y and drush cc all
*  Verify that your cloned resource view has the resource grid styling If you want, you can also change the formatting to table to ensure that these styling changes won't break tables.

