### PR TITLE
LUGG-658 Fixing SQL error in luggage_resources_update_7300()

### DIFF
--- a/luggage_resources.install
+++ b/luggage_resources.install
@@ -15,14 +15,11 @@ function luggage_resources_enable() {
  * Removes redundant fields: field_resource_meta and field_resource_title.
  */
 function luggage_resources_update_7300() {
-  $fieldname0 = 'field_resource_meta';
-  $fieldname1 = 'field_resource_title';
-
-  if ($field = field_info_field($fieldname0)) {
-    field_delete_field($field);
+  if (field_info_field('field_resource_meta') != NULL) {
+    field_delete_field('field_resource_meta');
   }
 
-  if ($field = field_info_field($fieldname1)) {
-    field_delete_field($field);
+  if (field_info_field('field_resource_title') != NULL) {
+    field_delete_field('field_resource_title');
   }
 }


### PR DESCRIPTION
When I was testing the luggage 3.4.1 upgrade process on ent I found a couple issues with luggage_resources_update_7300.

1. The comment format for the update hook was not quite formatted properly to show the update description when doing update.php or drush updb. The beginning of the comment must start with /** in order to be parsed correctly.

2. (and more serious). The update fails with an SQL error. as follows:

`Failed: PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' 'Array', 'Array', 'Array', 'Array', 'Array', 'Array', 'Array', , '0', 'field_sq' at line 2: SELECT fc.* FROM {field_config} fc WHERE (fc.field_name IN (, :db_condition_placeholder_1_0, :db_condition_placeholder_1_1, :db_condition_placeholder_1_2, :db_condition_placeholder_2_0, :db_condition_placeholder_2_1, :db_condition_placeholder_2_2, :db_condition_placeholder_2_3, , :db_condition_placeholder_4, :db_condition_placeholder_5_0, :db_condition_placeholder_5_1, :db_condition_placeholder_5_2, :db_condition_placeholder_5_3, :db_condition_placeholder_5_4, :db_condition_placeholder_6, :db_condition_placeholder_7, :db_condition_placeholder_8, :db_condition_placeholder_9, :db_condition_placeholder_10, :db_condition_placeholder_11, :db_condition_placeholder_12, :db_condition_placeholder_13, :db_condition_placeholder_14_0, :db_condition_placeholder_14_1, :db_condition_placeholder_14_2, :db_condition_placeholder_14_3, :db_condition_placeholder_14_4, :db_condition_placeholder_14_5, :db_condition_placeholder_14_6, :db_condition_placeholder_15_0)) AND (fc.active = :db_condition_placeholder_16) AND (fc.storage_active = :db_condition_placeholder_17) AND (fc.deleted = :db_condition_placeholder_18) ; Array ( [:db_condition_placeholder_4] => 0 [:db_condition_placeholder_6] => 55 [:db_condition_placeholder_7] => field_resource_meta [:db_condition_placeholder_8] => head_meta [:db_condition_placeholder_9] => multifield [:db_condition_placeholder_10] => 1 [:db_condition_placeholder_11] => 0 [:db_condition_placeholder_12] => -1 [:db_condition_placeholder_13] => 0 [:db_condition_placeholder_16] => 1 [:db_condition_placeholder_17] => 1 [:db_condition_placeholder_18] => 0 [:db_condition_placeholder_1_0] => Array ( [table] => filter_format [columns] => Array ( [field_attribute_format] => format ) ) [:db_condition_placeholder_1_1] => Array ( [table] => filter_format [columns] => Array ( [field_attribute_type_format] => format ) ) [:db_condition_placeholder_1_2] => Array ( [table] => filter_format [columns] => Array ( [field_content_format] => format ) ) [:db_condition_placeholder_2_0] => Array ( [0] => field_attribute_format ) [:db_condition_placeholder_2_1] => Array ( [0] => field_attribute_type_format ) [:db_condition_placeholder_2_2] => Array ( [0] => field_content_format ) [:db_condition_placeholder_2_3] => Array ( [0] => id ) [:db_condition_placeholder_5_0] => field_sql_storage [:db_condition_placeholder_5_1] => Array ( ) [:db_condition_placeholder_5_2] => field_sql_storage [:db_condition_placeholder_5_3] => 1 [:db_condition_placeholder_5_4] => Array ( [sql] => Array ( [FIELD_LOAD_CURRENT] => Array ( [field_data_field_resource_meta] => Array ( [field_attribute_value] => field_resource_meta_field_attribute_value [field_attribute_format] => field_resource_meta_field_attribute_format [field_attribute_type_value] => field_resource_meta_field_attribute_type_value [field_attribute_type_format] => field_resource_meta_field_attribute_type_format [field_content_value] => field_resource_meta_field_content_value [field_content_format] => field_resource_meta_field_content_format [id] => field_resource_meta_id ) ) [FIELD_LOAD_REVISION] => Array ( [field_revision_field_resource_meta] => Array ( [field_attribute_value] => field_resource_meta_field_attribute_value [field_attribute_format] => field_resource_meta_field_attribute_format [field_attribute_type_value] => field_resource_meta_field_attribute_type_value [field_attribute_type_format] => field_resource_meta_field_attribute_type_format [field_content_value] => field_resource_meta_field_content_value [field_content_format] => field_resource_meta_field_content_format [id] => field_resource_meta_id ) ) ) ) [:db_condition_placeholder_14_0] => Array ( [type] => varchar [length] => 255 [not null] => ) [:db_condition_placeholder_14_1] => Array ( [type] => varchar [length] => 255 [not null] => ) [:db_condition_placeholder_14_2] => Array ( [type] => varchar [length] => 255 [not null] => ) [:db_condition_placeholder_14_3] => Array ( [type] => varchar [length] => 255 [not null] => ) [:db_condition_placeholder_14_4] => Array ( [type] => text [size] => big [not null] => ) [:db_condition_placeholder_14_5] => Array ( [type] => varchar [length] => 255 [not null] => ) [:db_condition_placeholder_14_6] => Array ( [type] => int [unsigned] => 1 [not null] => 1 ) [:db_condition_placeholder_15_0] => Array ( [0] => resource ) ) in field_read_fields() (line 372 of /Users/jrearick/Sites/ent/modules/field/field.crud.inc).`

Looking at the code it looks like field_info_field returns an array. It is then fed into field_delete_field which is expecting a string and is just blindly passing an array to the SQL query instead of the string of the field name.