### PR TITLE
LUGG-529 Consistency in content types

### DIFF
--- a/luggage_resources.features.field_instance.inc
+++ b/luggage_resources.features.field_instance.inc
@@ -165,7 +165,7 @@ function luggage_resources_field_default_field_instances() {
       'module' => 'options',
       'settings' => array(),
       'type' => 'options_select',
-      'weight' => 2,
+      'weight' => 3,
     ),
   );
 
@@ -222,7 +222,7 @@ function luggage_resources_field_default_field_instances() {
       'module' => 'options',
       'settings' => array(),
       'type' => 'options_select',
-      'weight' => 3,
+      'weight' => 2,
     ),
   );
 


### PR DESCRIPTION
Moved resource category field above category field, to be more like other content types.