### PR TITLE
LUGG-640 Improved resource search result styling

### DIFF
--- a/css/luggage_resources.css
+++ b/css/luggage_resources.css
@@ -9,15 +9,18 @@
   color: rgb(36,109,73);
 }
 
-.field-name-field-resource-screenshot {
-  float: left;
-  padding: 15px 15px 15px 0px;
-}
-
 .field-name-field-resource-description {
   padding: 15px 0px;
 }
 
 .field-name-field-category {
   clear: both;
+}
+
+/*----- Search results -----*/
+@media all and (min-width: 740px) {
+    .field-name-field-resource-screenshot {
+      float: left;
+      padding: 15px 15px 15px 0px;
+    }
 }

--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -39,7 +39,8 @@ function luggage_resources_preprocess_page(&$vars) {
   if (!empty($node) && $node->type == 'resource' && arg(2) === null) {
     drupal_add_css(drupal_get_path('module', 'luggage_resources') . '/css/luggage_resources.css');
   }
-  if (arg(0) == 'node' && arg(1) == 'add' && arg(2) === 'resource') {
+  // Add styling for search results and node/add pages
+  if (arg(0) == 'search' || arg(0) == 'node' && arg(1) == 'add' && arg(2) === 'resource') {
     drupal_add_css(drupal_get_path('module', 'luggage_resources') . '/css/luggage_resources.css');
   }
 }


### PR DESCRIPTION
... as per John's request in the ticket.

![nrem_search_result](https://cloud.githubusercontent.com/assets/9325224/21897234/9acd623e-d8ae-11e6-9062-e377980e7523.png)

Made screenshots float above a certain resolution. On smaller screens, text won't wrap on the right side of the screenshot so that it's easier to read.