### PR TITLE
LUGG-1179 Get extension store screenshot image from og:image

### DIFF
--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -235,9 +235,17 @@ function _luggage_resources_get_url_data($url) {
 function luggage_resources_luggage_resources_dom_data($doc, &$data) {
   $parsed = parse_url($data['return']['url_actually_used']);
   if ($parsed['host'] == 'store.extension.iastate.edu') {    
-    $product_image_element = $doc->getElementByID('ContentPlaceHolder1_lnkProductPreview');
-    if ($product_image_element !== NULL) {
-      $data['return']['preferred_screenshot_url'] = $product_image_element->getAttribute('href');
+
+    // Get screenshot from meta og:image.
+    $metas = $doc->getElementsByTagName('meta');
+    foreach ($metas as $meta) {
+      foreach ($meta->attributes as $attr) {
+        if ($attr->name == 'property' && $attr->value == 'og:image') {
+          // str_replace backslashes with forward slashes because the value for og:image
+          // redirects to the version with the forward slashes.
+          $data['return']['preferred_screenshot_url'] = str_replace('\\', '/', $meta->getAttribute('content'));
+        }
+      }
     }
     
     $product_description_element = $doc->getElementByID('ContentPlaceHolder1_lblDescription');

--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -147,7 +147,7 @@ function _luggage_resources_index_url(&$form_state, $url) {
 
   // Get Screenshot into Drupal and add it to the form_state.
   if (isset($url_data['return']['preferred_screenshot_url'])) {
-    $file = system_retrieve_file($url_data['return']['preferred_screenshot_url'], NULL, TRUE, FILE_EXISTS_REPLACE);
+    $file = system_retrieve_file($url_data['return']['preferred_screenshot_url'], NULL, TRUE, FILE_EXISTS_RENAME);
     // Refresh image style derivatives.
     image_path_flush($file->uri);
   }

--- a/luggage_resources.module
+++ b/luggage_resources.module
@@ -241,9 +241,11 @@ function luggage_resources_luggage_resources_dom_data($doc, &$data) {
     foreach ($metas as $meta) {
       foreach ($meta->attributes as $attr) {
         if ($attr->name == 'property' && $attr->value == 'og:image') {
-          // str_replace backslashes with forward slashes because the value for og:image
-          // redirects to the version with the forward slashes.
-          $data['return']['preferred_screenshot_url'] = str_replace('\\', '/', $meta->getAttribute('content'));
+          if ($meta->getAttribute('content') !== NULL) {
+            // str_replace backslashes with forward slashes because the value for og:image
+            // redirects to the version with the forward slashes.
+            $data['return']['preferred_screenshot_url'] = str_replace('\\', '/', $meta->getAttribute('content'));
+          }
         }
       }
     }


### PR DESCRIPTION
To test:
* Create a new resource node for a extension store publication page. Eg. https://store.extension.iastate.edu/product/6451
* Note the screenshot that returns is not the cover picture, but an actual screenshot
* Apply this merge request
* Create another resouces for another product and see the image is the same as on the page.

You can also re-index an existing node to update the image as well.